### PR TITLE
feat: show category usage in period chart

### DIFF
--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -278,7 +278,14 @@ export default {
       return `/activity/${this.host}/${this.periodLength}`;
     },
     periodusage: function () {
-      return this.activityStore.getActiveHistoryAroundTimeperiod(this.timeperiod);
+      if (this.filter_category) {
+        return this.activityStore.getCategoryHistoryAroundTimeperiod(
+          this.timeperiod,
+          this.filter_category
+        );
+      } else {
+        return this.activityStore.getActiveHistoryAroundTimeperiod(this.timeperiod);
+      }
     },
     timeperiod: function () {
       const settingsStore = useSettingsStore();

--- a/src/visualizations/PeriodUsage.vue
+++ b/src/visualizations/PeriodUsage.vue
@@ -17,18 +17,28 @@ svg {
 // NOTE: This is just a Vue.js component wrapper for periodusage.js
 //       Code should generally go in the framework-independent file.
 
+import { PropType } from 'vue';
+import { IEvent } from '~/util/interfaces';
 import periodusage from './periodusage';
 
 export default {
   name: 'aw-periodusage',
   props: {
     periodusage_arr: {
-      type: Array,
+      type: Array as PropType<IEvent[][] | null>,
+      default: null,
     },
   },
   watch: {
-    periodusage_arr: function () {
-      periodusage.update(this.$el, this.periodusage_arr, this.onPeriodClicked);
+    periodusage_arr: {
+      handler() {
+        if (!this.periodusage_arr) {
+          periodusage.set_status(this.$el, 'Loading...');
+        } else {
+          periodusage.update(this.$el, this.periodusage_arr, this.onPeriodClicked);
+        }
+      },
+      immediate: true,
     },
   },
   mounted: function () {

--- a/src/visualizations/periodusage.ts
+++ b/src/visualizations/periodusage.ts
@@ -2,6 +2,7 @@ import * as d3 from 'd3';
 import _ from 'lodash';
 import moment from 'moment';
 
+import { IEvent } from '~/util/interfaces';
 import { seconds_to_duration, get_hour_offset } from '../util/time.ts';
 
 function create(svg_elem: SVGElement) {
@@ -29,7 +30,11 @@ const diagramcolor = '#aaa';
 const diagramcolor_selected = '#fc5';
 const diagramcolor_focused = '#adf';
 
-function update(svg_elem: SVGElement, usage_arr, onPeriodClicked) {
+function update(
+  svg_elem: SVGElement,
+  usage_arr: IEvent[][],
+  onPeriodClicked: (period: string) => void
+) {
   const dateformat = 'YYYY-MM-DD';
 
   // No apps, sets status to "No data"
@@ -40,12 +45,11 @@ function update(svg_elem: SVGElement, usage_arr, onPeriodClicked) {
   svg_elem.innerHTML = '';
   const svg = d3.select(svg_elem);
 
-  function get_usage_time(day_events) {
-    const day_event = _.head(_.filter(day_events, e => e.data.status == 'not-afk'));
-    return day_event != undefined ? day_event.duration : 0;
+  function get_usage_time(day_events: IEvent[]) {
+    return _.sumBy(day_events, e => e.duration);
   }
 
-  const usage_times = usage_arr.map(day_events => get_usage_time(day_events));
+  const usage_times = usage_arr.map((day_events: IEvent[]) => get_usage_time(day_events));
   let longest_usage = Math.max.apply(null, usage_times);
   // Avoid division by zero
   if (longest_usage <= 0) {


### PR DESCRIPTION
## Summary
- show category-based durations in period chart
- add loading indicator when category filter changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c09b6a7cf48321a5486a0c69a7403a
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add category-based durations to period chart and loading indicator for category filter changes.
> 
>   - **Behavior**:
>     - Show category-based durations in period chart using `getCategoryHistoryAroundTimeperiod` in `activity.ts`.
>     - Add loading indicator in `PeriodUsage.vue` when category filter changes.
>   - **Components**:
>     - Update `Activity.vue` to use `getCategoryHistoryAroundTimeperiod` for category data.
>     - Modify `PeriodUsage.vue` to display loading message when `periodusage_arr` is null.
>   - **Data Structures**:
>     - Change `category.by_period` to `Record<string, { cat_events: IEvent[] }> | null` in `activity.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RTnhN%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 695db46f5d83faa327a6f5d31ed6661b9a93df47. You can [customize](https://app.ellipsis.dev/RTnhN/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->