### PR TITLE
Show loading while recalculating category-based period usage

### DIFF
--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -570,7 +570,9 @@ export const useActivityStore = defineStore('activity', {
       always_active_pattern,
       host,
     }: QueryOptions) {
-      const filter_category = filter_categories ? filter_categories[0] : null;
+      // Fall back to the last used filter_categories if the caller didn't supply one
+      const categoriesFilter = filter_categories ?? this.query_options?.filter_categories ?? null;
+      const filter_category = categoriesFilter ? categoriesFilter[0] : null;
       const key = categoryHistoryKey(host, filter_category);
       if (!this.category.history[key]) {
         this.category.history[key] = {};
@@ -598,7 +600,7 @@ export const useActivityStore = defineStore('activity', {
               ? this.buckets.stopwatch[0]
               : undefined,
           categories,
-          filter_categories,
+          filter_categories: categoriesFilter,
           filter_afk,
           always_active_pattern,
           ...(isAndroid

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -230,10 +230,12 @@ export const useActivityStore = defineStore('activity', {
         const periods = timeperiodStrsAroundTimeperiod(timeperiod);
         const historyForKey = this.category.history[key] || {};
         return periods.map(tp => {
-          if (_.has(historyForKey, tp)) {
-            return historyForKey[tp];
+          const events = historyForKey[tp] || [];
+          if (events.length > 0) {
+            return events;
           } else {
-            return [];
+            // Add zero-duration placeholder so period columns always have a date
+            return [{ timestamp: moment(tp.split('/')[0]).format(), duration: 0, data: {} }];
           }
         });
       };

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -279,6 +279,9 @@ export default {
       return `/activity/${this.host}/${this.periodLength}`;
     },
     periodusage: function () {
+      // Touch the category history to ensure reactivity when it updates
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      this.activityStore.category.history;
       return this.activityStore.getCategoryHistoryAroundTimeperiod(
         this.timeperiod,
         this.host,

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -279,7 +279,11 @@ export default {
       return `/activity/${this.host}/${this.periodLength}`;
     },
     periodusage: function () {
-      return this.activityStore.getCategoryHistoryAroundTimeperiod(this.timeperiod);
+      return this.activityStore.getCategoryHistoryAroundTimeperiod(
+        this.timeperiod,
+        this.host,
+        this.filter_category
+      );
     },
     timeperiod: function () {
       const settingsStore = useSettingsStore();

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -72,7 +72,7 @@ div
         b-form-select(v-model="filter_category", :options="categoryStore.category_select(true)" size="sm")
 
 
-  aw-periodusage.mt-2(:periodusage_arr="periodusage", @update="setDate")
+  aw-periodusage.mt-2(:periodusage_arr="periodusage", :loading="periodusageLoading", @update="setDate")
 
   aw-uncategorized-notification()
 
@@ -203,6 +203,7 @@ export default {
       include_stopwatch: false,
       filter_afk: true,
       new_view: {},
+      periodusageLoading: false,
     };
   },
   computed: {
@@ -278,7 +279,7 @@ export default {
       return `/activity/${this.host}/${this.periodLength}`;
     },
     periodusage: function () {
-      return this.activityStore.getActiveHistoryAroundTimeperiod(this.timeperiod);
+      return this.activityStore.getCategoryHistoryAroundTimeperiod(this.timeperiod);
     },
     timeperiod: function () {
       const settingsStore = useSettingsStore();
@@ -412,6 +413,7 @@ export default {
     },
 
     refresh: async function (force) {
+      this.periodusageLoading = true;
       const queryOptions: QueryOptions = {
         timeperiod: this.timeperiod,
         host: this.host,
@@ -422,7 +424,12 @@ export default {
         filter_categories: this.filter_categories,
         always_active_pattern: this.always_active_pattern,
       };
-      await this.activityStore.ensure_loaded(queryOptions);
+      try {
+        await this.activityStore.ensure_loaded(queryOptions);
+        await this.activityStore.query_category_history(queryOptions);
+      } finally {
+        this.periodusageLoading = false;
+      }
     },
 
     load_demo: async function () {

--- a/src/views/activity/Activity.vue
+++ b/src/views/activity/Activity.vue
@@ -332,7 +332,7 @@ export default {
       this.refresh();
     },
     timeperiod: function () {
-      this.refresh();
+      this.refresh(false, false);
     },
     filter_category: function () {
       this.refresh();
@@ -412,8 +412,10 @@ export default {
       }
     },
 
-    refresh: async function (force) {
-      this.periodusageLoading = true;
+    refresh: async function (force = false, showLoading = true) {
+      if (showLoading) {
+        this.periodusageLoading = true;
+      }
       const queryOptions: QueryOptions = {
         timeperiod: this.timeperiod,
         host: this.host,
@@ -428,7 +430,9 @@ export default {
         await this.activityStore.ensure_loaded(queryOptions);
         await this.activityStore.query_category_history(queryOptions);
       } finally {
-        this.periodusageLoading = false;
+        if (showLoading) {
+          this.periodusageLoading = false;
+        }
       }
     },
 

--- a/src/visualizations/PeriodUsage.vue
+++ b/src/visualizations/PeriodUsage.vue
@@ -25,15 +25,32 @@ export default {
     periodusage_arr: {
       type: Array,
     },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
   },
   watch: {
     periodusage_arr: function () {
-      periodusage.update(this.$el, this.periodusage_arr, this.onPeriodClicked);
+      if (!this.loading) {
+        periodusage.update(this.$el, this.periodusage_arr, this.onPeriodClicked);
+      }
+    },
+    loading: function (val) {
+      if (val) {
+        periodusage.set_status(this.$el, 'Loading...');
+      } else {
+        periodusage.update(this.$el, this.periodusage_arr, this.onPeriodClicked);
+      }
     },
   },
   mounted: function () {
     periodusage.create(this.$el);
-    periodusage.set_status(this.$el, 'Loading...');
+    if (this.loading) {
+      periodusage.set_status(this.$el, 'Loading...');
+    } else {
+      periodusage.update(this.$el, this.periodusage_arr, this.onPeriodClicked);
+    }
   },
   methods: {
     onPeriodClicked: function (period) {

--- a/src/visualizations/periodusage.ts
+++ b/src/visualizations/periodusage.ts
@@ -41,8 +41,7 @@ function update(svg_elem: SVGElement, usage_arr, onPeriodClicked) {
   const svg = d3.select(svg_elem);
 
   function get_usage_time(day_events) {
-    const day_event = _.head(_.filter(day_events, e => e.data.status == 'not-afk'));
-    return day_event != undefined ? day_event.duration : 0;
+    return _.sumBy(day_events, 'duration');
   }
 
   const usage_times = usage_arr.map(day_events => get_usage_time(day_events));


### PR DESCRIPTION
## Summary
- Tie period usage chart to category history instead of raw non-AFK time
- Add loading indicator to period usage component when filters change
- Track and query category history in activity store

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c09ffd93208321bf545acc0e78f3f1
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds loading indicator for period usage and ties chart to category history in `activity.ts`, updating `Activity.vue` and `PeriodUsage.vue`.
> 
>   - **Behavior**:
>     - Period usage chart now uses category history instead of raw non-AFK time in `activity.ts`.
>     - Adds loading indicator to `PeriodUsage.vue` when filters change, managed by `loading` prop.
>     - Tracks and queries category history in `activity.ts` with `getCategoryHistoryAroundTimeperiod()` and `query_category_history()`.
>   - **Components**:
>     - Updates `Activity.vue` to handle loading state with `periodusageLoading` and query category history.
>     - `PeriodUsage.vue` updated to display loading status using `set_status()`.
>   - **Functions**:
>     - Adds `categoryHistoryKey()` and `getCategoryHistoryAroundTimeperiod()` in `activity.ts`.
>     - Implements `query_category_history()` in `activity.ts` to fetch category history data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RTnhN%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 3bd39d9236a5c254da2390f8dc846fa682e7726f. You can [customize](https://app.ellipsis.dev/RTnhN/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->