### PR TITLE
feat: show category usage with loading indicator

### DIFF
--- a/src/visualizations/PeriodUsage.vue
+++ b/src/visualizations/PeriodUsage.vue
@@ -25,15 +25,32 @@ export default {
     periodusage_arr: {
       type: Array,
     },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
   },
   watch: {
     periodusage_arr: function () {
-      periodusage.update(this.$el, this.periodusage_arr, this.onPeriodClicked);
+      if (this.loading || !this.periodusage_arr || this.periodusage_arr.length === 0) {
+        periodusage.set_status(this.$el, 'Loading...');
+      } else {
+        periodusage.update(this.$el, this.periodusage_arr, this.onPeriodClicked);
+      }
+    },
+    loading: function (val) {
+      if (val) {
+        periodusage.set_status(this.$el, 'Loading...');
+      } else if (this.periodusage_arr && this.periodusage_arr.length > 0) {
+        periodusage.update(this.$el, this.periodusage_arr, this.onPeriodClicked);
+      }
     },
   },
   mounted: function () {
     periodusage.create(this.$el);
-    periodusage.set_status(this.$el, 'Loading...');
+    if (this.loading) {
+      periodusage.set_status(this.$el, 'Loading...');
+    }
   },
   methods: {
     onPeriodClicked: function (period) {

--- a/src/visualizations/periodusage.ts
+++ b/src/visualizations/periodusage.ts
@@ -32,7 +32,7 @@ const diagramcolor_focused = '#adf';
 function update(svg_elem: SVGElement, usage_arr, onPeriodClicked) {
   const dateformat = 'YYYY-MM-DD';
 
-  // No apps, sets status to "No data"
+  // No data, sets status to "No data"
   if (usage_arr.length <= 0) {
     set_status(svg_elem, 'No data');
     return;
@@ -40,12 +40,11 @@ function update(svg_elem: SVGElement, usage_arr, onPeriodClicked) {
   svg_elem.innerHTML = '';
   const svg = d3.select(svg_elem);
 
-  function get_usage_time(day_events) {
-    const day_event = _.head(_.filter(day_events, e => e.data.status == 'not-afk'));
-    return day_event != undefined ? day_event.duration : 0;
+  function get_usage_time(day) {
+    return _.sumBy(day.events, 'duration');
   }
 
-  const usage_times = usage_arr.map(day_events => get_usage_time(day_events));
+  const usage_times = usage_arr.map(day => get_usage_time(day));
   let longest_usage = Math.max.apply(null, usage_times);
   // Avoid division by zero
   if (longest_usage <= 0) {
@@ -56,13 +55,12 @@ function update(svg_elem: SVGElement, usage_arr, onPeriodClicked) {
   const width = 100 / usage_arr.length - padding;
   const center_elem = Math.floor(usage_arr.length / 2);
 
-  _.each(usage_arr, (events, i: number) => {
-    const usage_time = get_usage_time(events);
+  _.each(usage_arr, (day, i: number) => {
+    const usage_time = get_usage_time(day);
     const height = 85 * (usage_time / longest_usage);
     let date = '';
-    if (events.length > 0) {
-      // slice off so it's only the day
-      date = moment(events[0].timestamp).subtract(get_hour_offset(), 'hours').format(dateformat);
+    if (day.period) {
+      date = moment(day.period.split('/')[0]).subtract(get_hour_offset(), 'hours').format(dateformat);
     }
     const color = i === center_elem ? diagramcolor_selected : diagramcolor;
     const offset = 50;


### PR DESCRIPTION
## Summary
- show loading state in period usage chart
- derive period usage from category data
- refresh chart on category filter changes without losing bars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4b88439608321996e590dd6c30cb9