### PR TITLE
feat: make delete work recursively

### DIFF
--- a/src/components/CategoryEditModal.vue
+++ b/src/components/CategoryEditModal.vue
@@ -57,7 +57,7 @@ b-modal(id="edit" ref="edit" title="Edit category" @show="resetModal" @hidden="h
 
   hr
   div.my-1
-    b-btn(variant="danger", @click="removeClass(categoryId); $refs.edit.hide()")
+    b-btn(variant="danger", @click="handleRemove")
       icon(name="trash")
       | Remove category
 </template>
@@ -133,6 +133,23 @@ export default {
       }
       return this.editing.rule.regex || '';
     },
+    removalCandidates() {
+      const category = this.categoryStore.get_category_by_id(this.categoryId);
+      if (!category) return [];
+
+      const candidates = this.categoryStore.classes
+        .filter(c => _.isEqual(c.name.slice(0, category.name.length), category.name))
+        .sort((a, b) => a.name.length - b.name.length || a.name.join('>').localeCompare(b.name.join('>')));
+
+      return candidates.map(c => {
+        const depth = c.name.length - category.name.length;
+        return {
+          key: c.id ?? c.name.join('>'),
+          depth,
+          text: c.name.join(' > '),
+        };
+      });
+    },
   },
   watch: {
     categoryId: function (new_value) {
@@ -168,10 +185,32 @@ export default {
     hidden() {
       this.$emit('hidden');
     },
-    removeClass() {
-      // TODO: Show a confirmation dialog
-      // TODO: Remove children as well?
+    handleRemove() {
+      const category = this.categoryStore.get_category_by_id(this.categoryId);
+      if (!category) {
+        console.error('Could not find category to remove:', this.categoryId);
+        return;
+      }
+
+      const descendants = this.removalCandidates;
+      // Subtract the category itself
+      const childCount = Math.max(descendants.length - 1, 0);
+
+      if (
+        childCount > 0 &&
+        !confirm(
+          `This category has ${childCount} subcategor${
+            childCount === 1 ? 'y' : 'ies'
+          }. Deleting it will also delete the children:\n\n${descendants
+            .map(d => '- '.padStart(2 + d.depth * 2, ' ') + d.text)
+            .join('\n')}\n\nContinue?`
+        )
+      ) {
+        return;
+      }
+
       this.categoryStore.removeClass(this.categoryId);
+      this.$refs.edit.hide();
     },
     checkFormValidity() {
       return this.valid;

--- a/src/components/CategoryEditModal.vue
+++ b/src/components/CategoryEditModal.vue
@@ -139,7 +139,10 @@ export default {
 
       const candidates = this.categoryStore.classes
         .filter(c => _.isEqual(c.name.slice(0, category.name.length), category.name))
-        .sort((a, b) => a.name.length - b.name.length || a.name.join('>').localeCompare(b.name.join('>')));
+        .sort(
+          (a, b) =>
+            a.name.length - b.name.length || a.name.join('>').localeCompare(b.name.join('>'))
+        );
 
       return candidates.map(c => {
         const depth = c.name.length - category.name.length;

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -181,7 +181,15 @@ export const useCategoryStore = defineStore('categories', {
       this.classes_unsaved_changes = true;
     },
     removeClass(this: State, classId: number) {
-      this.classes = this.classes.filter((c: Category) => c.id !== classId);
+      const target = this.classes.find((c: Category) => c.id === classId);
+      if (!target) {
+        console.warn(`Couldn't find category with id ${classId} to remove.`);
+        return;
+      }
+
+      this.classes = this.classes.filter(
+        (c: Category) => !_.isEqual(c.name.slice(0, target.name.length), target.name)
+      );
       this.classes_unsaved_changes = true;
     },
     appendClassRule(this: State, classId: number, pattern: string) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable recursive deletion of categories and subcategories with user confirmation in `CategoryEditModal.vue` and `categories.ts`.
> 
>   - **Behavior**:
>     - `handleRemove` in `CategoryEditModal.vue` now deletes categories recursively, confirming with the user if subcategories exist.
>     - `removeClass` in `categories.ts` updated to remove all subcategories of the target category.
>   - **Methods**:
>     - Adds `removalCandidates` computed property in `CategoryEditModal.vue` to list subcategories for confirmation.
>     - Updates `removeClass` in `categories.ts` to filter out subcategories based on name hierarchy.
>   - **UI**:
>     - Confirmation dialog in `handleRemove` lists subcategories to be deleted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RTnhN%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for 1e03f6ba1892390c22b965770fc015c1f3b25aa3. You can [customize](https://app.ellipsis.dev/RTnhN/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->