### PR TITLE
fix: change wrong vis name

### DIFF
--- a/src/components/SelectableVisualization.vue
+++ b/src/components/SelectableVisualization.vue
@@ -77,7 +77,7 @@ div
       aw-categorytree(:events="activityStore.category.top")
     div(v-if="type == 'category_sunburst'")
       aw-sunburst-categories(:data="top_categories_hierarchy", style="height: 20em")
-    div(v-if="type == 'watcher_sunburst'")
+    div(v-if="type == 'watcher_columns'")
       aw-watcher-columns(
         :initialBucketId="props ? props.bucketId : ''",
         :initialField="props ? props.field : ''",
@@ -161,7 +161,7 @@ export default {
         'top_categories',
         'category_tree',
         'category_sunburst',
-        'watcher_sunburst',
+        'watcher_columns',
         'top_editor_files',
         'top_editor_languages',
         'top_editor_projects',
@@ -240,7 +240,7 @@ export default {
           title: 'Category Sunburst',
           available: this.activityStore.category.available,
         },
-        watcher_sunburst: {
+        watcher_columns: {
           title: 'Watcher Columns',
           available: true,
         },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change visualization type name from `watcher_sunburst` to `watcher_columns` in `SelectableVisualization.vue`.
> 
>   - **Behavior**:
>     - Change visualization type name from `watcher_sunburst` to `watcher_columns` in `SelectableVisualization.vue`.
>     - Affects conditional rendering for `aw-watcher-columns` component.
>   - **Visualizations Object**:
>     - Update `visualizations` object to reflect the new type name `watcher_columns` with title 'Watcher Columns'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RTnhN%2Faw-webui&utm_source=github&utm_medium=referral)<sup> for b10fe6d927cf407fe71d0b82ca329da4716f0e86. You can [customize](https://app.ellipsis.dev/RTnhN/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->